### PR TITLE
add per-resolver socket factory

### DIFF
--- a/dns/query.pyi
+++ b/dns/query.pyi
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Dict, Generator, Any
+from typing import Optional, Union, Dict, Generator, Any, Callable
 from . import tsig, rdatatype, rdataclass, name, message
 from requests.sessions import Session
 
@@ -31,7 +31,8 @@ def tcp(q : message.Message, where : str, timeout : float = None, port=53,
         source_port : Optional[int] = 0,
         one_rr_per_rrset : Optional[bool] = False,
         ignore_trailing : Optional[bool] = False,
-        sock : Optional[socket.socket] = None) -> message.Message:
+        sock : Optional[socket.socket] = None,
+        socket_factory : Optional[Callable] = None) -> message.Message:
     pass
 
 def xfr(where : None, zone : Union[name.Name,str], rdtype=rdatatype.AXFR,
@@ -51,7 +52,8 @@ def udp(q : message.Message, where : str, timeout : Optional[float] = None,
         ignore_unexpected : Optional[bool] = False,
         one_rr_per_rrset : Optional[bool] = False,
         ignore_trailing : Optional[bool] = False,
-        sock : Optional[socket.socket] = None) -> message.Message:
+        sock : Optional[socket.socket] = None,
+        socket_factory : Optional[Callable] = None) -> message.Message:
     pass
 
 def tls(q : message.Message, where : str, timeout : Optional[float] = None,

--- a/dns/resolver.py
+++ b/dns/resolver.py
@@ -1102,6 +1102,14 @@ class BaseResolver:
 class Resolver(BaseResolver):
     """DNS stub resolver."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.socket_factory = None
+
+    def reset(self):
+        super().reset()
+        self.socket_factory = None
+
     def resolve(self, qname, rdtype=dns.rdatatype.A, rdclass=dns.rdataclass.IN,
                 tcp=False, source=None, raise_on_no_answer=True, source_port=0,
                 lifetime=None, search=None):  # pylint: disable=arguments-differ
@@ -1177,19 +1185,25 @@ class Resolver(BaseResolver):
                 try:
                     if dns.inet.is_address(nameserver):
                         if tcp:
-                            response = dns.query.tcp(request, nameserver,
-                                                     timeout=timeout,
-                                                     port=port,
-                                                     source=source,
-                                                     source_port=source_port)
+                            response = dns.query.tcp(
+                                request, nameserver,
+                                timeout=timeout,
+                                port=port,
+                                source=source,
+                                source_port=source_port,
+                                socket_factory=self.socket_factory,
+                            )
                         else:
-                            response = dns.query.udp(request,
-                                                     nameserver,
-                                                     timeout=timeout,
-                                                     port=port,
-                                                     source=source,
-                                                     source_port=source_port,
-                                                     raise_on_truncation=True)
+                            response = dns.query.udp(
+                                request,
+                                nameserver,
+                                timeout=timeout,
+                                port=port,
+                                source=source,
+                                source_port=source_port,
+                                raise_on_truncation=True,
+                                socket_factory=self.socket_factory,
+                            )
                     else:
                         protocol = urlparse(nameserver).scheme
                         if protocol != 'https':


### PR DESCRIPTION
This pull request adds support for per-Resolver socket factory for UDP and TCP queries.

A custom socket factory is currently supported in the `dns.query` module. However, by being module-level, it is not flexible enough to support per-destination customization. For example, when a socket needs to be bound to an interface before usage.